### PR TITLE
Surf Tutorial Fixes + Clarifications

### DIFF
--- a/labs/01-AXI-Lite_register_endpoint/README.md
+++ b/labs/01-AXI-Lite_register_endpoint/README.md
@@ -672,7 +672,7 @@ tb.log.custom( f'buildString={buildString}' )
 
 Now, run the cocoTB python script and grep for the CUSTOM logging prints
 ```bash
-pytest --capture=tee-sys --log-cli-level=INFO tests/test_MyAxiLiteEndpointWrapper.py  | grep CUSTOM
+pytest --capture=tee-sys --log-cli-level=INFO tests/test_MyAxiLiteEndpointWrapper.py | grep CUSTOM
 ```
 
 Here's an example of what the output of that `pytest` command would look like:

--- a/labs/02-AXI-stream_module/README.md
+++ b/labs/02-AXI-stream_module/README.md
@@ -64,10 +64,10 @@ Primary purpose is to help with visually looking at simulation waveforms.
 Generic that contain the AXI stream configurations
   - TSTRB_EN_C         : boolean; -- Configure if tStrb used or not
   - TDATA_BYTES_C      : natural range 1 to AXI_STREAM_MAX_TKEEP_WIDTH_C; -- tData width (in units of bytes)
-  - TDEST_BITS_C       : natural range 0 to 8; -- Number of tDest bits (optional metadata field)
-  - TID_BITS_C         : natural range 0 to 8; -- Number of tId bits (optional metadata field)
+  - TDEST_BITS_C       : natural range 0 to 8; -- Number of tDest bits (optional side-channel data field)
+  - TID_BITS_C         : natural range 0 to 8; -- Number of tId bits (optional side-channel data field)
   - TKEEP_MODE_C       : TkeepModeType; -- Method for tKeep implementation to improve logical resource utilization
-  - TUSER_BITS_C       : natural range 0 to 8; -- Number of tUser bits (optional metadata field)
+  - TUSER_BITS_C       : natural range 0 to 8; -- Number of tUser bits (optional side-channel data field)
   - TUSER_MODE_C       : TUserModeType; -- Method for tUser implementation to improve logical resource utilization
 * `axisClk`: AXI stream clock
 * `axisRst`: AXI stream reset (active HIGH)
@@ -176,7 +176,7 @@ Next, add the following code to the "Flow Control" section:
       -- Check if the outbound tReady was active
       if (mAxisSlave.tReady = '1') then
 
-         -- Reset the outbound metadata
+         -- Reset the outbound side-channel data
          v.mAxisMaster.tValid := '0';
 
       end if;

--- a/labs/02-AXI-stream_module/README.md
+++ b/labs/02-AXI-stream_module/README.md
@@ -64,10 +64,10 @@ Primary purpose is to help with visually looking at simulation waveforms.
 Generic that contain the AXI stream configurations
   - TSTRB_EN_C         : boolean; -- Configure if tStrb used or not
   - TDATA_BYTES_C      : natural range 1 to AXI_STREAM_MAX_TKEEP_WIDTH_C; -- tData width (in units of bytes)
-  - TDEST_BITS_C       : natural range 0 to 8; -- Number of tDest bits (optional side-channel data field)
-  - TID_BITS_C         : natural range 0 to 8; -- Number of tId bits (optional side-channel data field)
+  - TDEST_BITS_C       : natural range 0 to 8; -- Number of tDest bits (optional metadata field)
+  - TID_BITS_C         : natural range 0 to 8; -- Number of tId bits (optional metadata field)
   - TKEEP_MODE_C       : TkeepModeType; -- Method for tKeep implementation to improve logical resource utilization
-  - TUSER_BITS_C       : natural range 0 to 8; -- Number of tUser bits (optional side-channel data field)
+  - TUSER_BITS_C       : natural range 0 to 8; -- Number of tUser bits (optional metadata field)
   - TUSER_MODE_C       : TUserModeType; -- Method for tUser implementation to improve logical resource utilization
 * `axisClk`: AXI stream clock
 * `axisRst`: AXI stream reset (active HIGH)
@@ -176,7 +176,7 @@ Next, add the following code to the "Flow Control" section:
       -- Check if the outbound tReady was active
       if (mAxisSlave.tReady = '1') then
 
-         -- Reset the outbound side-channel data
+         -- Reset the outbound metadata
          v.mAxisMaster.tValid := '0';
 
       end if;

--- a/labs/02-AXI-stream_module/README.md
+++ b/labs/02-AXI-stream_module/README.md
@@ -467,7 +467,7 @@ async def run_test(dut, payload_lengths=None, payload_data=None, idle_inserter=N
 
 Now, run the cocoTB python script and grep for the CUSTOM logging prints
 ```bash
-pytest --capture=tee-sys --log-cli-level=INFO tests/test_MyAxiStreamModuleWrapper.py  | grep CUSTOM
+pytest --capture=tee-sys --log-cli-level=INFO tests/test_MyAxiStreamModuleWrapper.py | grep CUSTOM
 ```
 
 Here's an example of what the output of that `pytest` command would look like:

--- a/labs/02-AXI-stream_module/README.md
+++ b/labs/02-AXI-stream_module/README.md
@@ -222,6 +222,8 @@ deassert sAxisMaster.tValid or re-assert sAxisMaster.tValid with new information
 <!--- ########################################################################################### -->
 
 ### Outputs
+
+Replace `-- Outputs: Placeholder for your code will go here` with the following code:
 ```vhdl
       sAxisSlave  <= v.sAxisSlave;  -- Variable output
       mAxisMaster <= r.mAxisMaster; -- Registered output

--- a/labs/02-AXI-stream_module/ref_files/MyAxiStreamModule_final.vhd
+++ b/labs/02-AXI-stream_module/ref_files/MyAxiStreamModule_final.vhd
@@ -72,7 +72,7 @@ begin
       -- Check if the outbound tReady was active
       if (mAxisSlave.tReady = '1') then
 
-         -- Reset the outbound metadata
+         -- Reset the outbound side-channel data
          v.mAxisMaster.tValid := '0';
 
       end if;

--- a/labs/02-AXI-stream_module/ref_files/MyAxiStreamModule_final.vhd
+++ b/labs/02-AXI-stream_module/ref_files/MyAxiStreamModule_final.vhd
@@ -72,7 +72,7 @@ begin
       -- Check if the outbound tReady was active
       if (mAxisSlave.tReady = '1') then
 
-         -- Reset the outbound side-channel data
+         -- Reset the outbound metadata
          v.mAxisMaster.tValid := '0';
 
       end if;

--- a/labs/03-AXI-Lite_crossbar/README.md
+++ b/labs/03-AXI-Lite_crossbar/README.md
@@ -414,7 +414,7 @@ In the `test_MyAxiLiteCrossbarWrapper.py`, the `run_test_bytes()` and `run_stres
 
 Now, run the cocoTB python script and grep for the CUSTOM logging prints
 ```bash
-pytest --capture=tee-sys --log-cli-level=INFO tests/test_MyAxiLiteCrossbarWrapper.py  | grep CUSTOM
+pytest --capture=tee-sys --log-cli-level=INFO tests/test_MyAxiLiteCrossbarWrapper.py | grep CUSTOM
 ```
 
 Here's an example of what the output of that `pytest` command would look like:

--- a/labs/03-AXI-Lite_crossbar/README.md
+++ b/labs/03-AXI-Lite_crossbar/README.md
@@ -53,7 +53,7 @@ entity MyAxiLiteCrossbar is
       axilReadSlave   : out AxiLiteReadSlaveType;
       axilWriteMaster : in  AxiLiteWriteMasterType;
       axilWriteSlave  : out AxiLiteWriteSlaveType);
-end MyAxiLiteCrossbarWrapper;
+end MyAxiLiteCrossbar;
 ```
 * `TPD_G`: Simulation only generic used to add delay after the register stage.
 This generic has no impact to synthesis or Place and Route (PnR).

--- a/labs/03-AXI-Lite_crossbar/README.md
+++ b/labs/03-AXI-Lite_crossbar/README.md
@@ -166,14 +166,6 @@ is used when the crossbar slave address mapping is periodic via a "stride".  In 
 
 Replace "-- Placeholder for signals" with the following signals:
 ```vhdl
-   signal axilClk : sl;
-   signal axilRst : sl;
-
-   signal axilReadMaster  : AxiLiteReadMasterType;
-   signal axilReadSlave   : AxiLiteReadSlaveType;
-   signal axilWriteMaster : AxiLiteWriteMasterType;
-   signal axilWriteSlave  : AxiLiteWriteSlaveType;
-
    signal axilReadMasters  : AxiLiteReadMasterArray(NUM_AXIL_MASTERS_C-1 downto 0);
    signal axilReadSlaves   : AxiLiteReadSlaveArray(NUM_AXIL_MASTERS_C-1 downto 0);
    signal axilWriteMasters : AxiLiteWriteMasterArray(NUM_AXIL_MASTERS_C-1 downto 0);
@@ -184,39 +176,6 @@ Replace "-- Placeholder for signals" with the following signals:
    signal cascadeWriteMasters : AxiLiteWriteMasterArray(NUM_CASCADE_MASTERS_C-1 downto 0);
    signal cascadeWriteSlaves  : AxiLiteWriteSlaveArray(NUM_CASCADE_MASTERS_C-1 downto 0);
 ```
-* `axilClk`: AXI-Lite clock
-* `axilRst`: AXI-Lite reset (active HIGH)
-* `axilReadMaster`: AXI-Lite read master input.
-[`AxiLiteReadMasterType](https://github.com/slaclab/surf/blob/v2.47.1/axi/axi-lite/rtl/AxiLitePkg.vhd#L56) record type
-contains the following signals (defined in [AxiLitePkg](https://github.com/slaclab/surf/blob/v2.47.1/axi/axi-lite/rtl/AxiLitePkg.vhd)):
-  - araddr  : slv(31 downto 0);
-  - arprot  : slv(2 downto 0);
-  - arvalid : sl;
-  - rready  : sl;
-* `axilReadSlave`: AXI-Lite read slave output.
-[`AxiLiteReadSlaveType](https://github.com/slaclab/surf/blob/v2.47.1/axi/axi-lite/rtl/AxiLitePkg.vhd#L82) record type
-contains the following signals (defined in [AxiLitePkg](https://github.com/slaclab/surf/blob/v2.47.1/axi/axi-lite/rtl/AxiLitePkg.vhd)):
-  - arready : sl;
-  - rdata   : slv(31 downto 0);
-  - rresp   : slv(1 downto 0);
-  - rvalid  : sl;
-* `axilWriteMaster`: AXI-Lite write master input.
-[`AxiLiteWriteMasterType](https://github.com/slaclab/surf/blob/v2.47.1/axi/axi-lite/rtl/AxiLitePkg.vhd#L117) record type
-contains the following signals (defined in [AxiLitePkg](https://github.com/slaclab/surf/blob/v2.47.1/axi/axi-lite/rtl/AxiLitePkg.vhd)):
-  - awaddr  : slv(31 downto 0);
-  - awprot  : slv(2 downto 0);
-  - awvalid : sl;
-  - wdata   : slv(31 downto 0);
-  - wstrb   : slv(3 downto 0);
-  - wvalid  : sl;
-  - bready  : sl;
-* `axilWriteSlave`: AXI-Lite write slave output.
-[`AxiLiteWriteSlaveType](https://github.com/slaclab/surf/blob/v2.47.1/axi/axi-lite/rtl/AxiLitePkg.vhd#L150) record type
-contains the following signals (defined in [AxiLitePkg](https://github.com/slaclab/surf/blob/v2.47.1/axi/axi-lite/rtl/AxiLitePkg.vhd)):
-  - awready : sl;
-  - wready  : sl;
-  - bresp   : slv(1 downto 0);
-  - bvalid  : sl;
 * `axilReadMasters` is an array of AXI-Lite read master buses from first crossbar.
 [`AxiLiteReadMasterArray`](https://github.com/slaclab/surf/blob/v2.47.1/axi/axi-lite/rtl/AxiLitePkg.vhd#L74) record type
 * `axilReadSlaves` is an array of AXI-Lite read slave buses from first crossbar.

--- a/labs/04-AXI-stream_mux_demux/README.md
+++ b/labs/04-AXI-stream_mux_demux/README.md
@@ -408,7 +408,7 @@ async def run_test(dut, payload_lengths=None, payload_data=None, idle_inserter=N
 
 Now, run the cocoTB python script and grep for the CUSTOM logging prints
 ```bash
-pytest --capture=tee-sys --log-cli-level=INFO tests/test_MyAxiStreamMuxDemuxWrapper.py  | grep CUSTOM
+pytest --capture=tee-sys --log-cli-level=INFO tests/test_MyAxiStreamMuxDemuxWrapper.py | grep CUSTOM
 ```
 
 Here's an example of what the output of that `pytest` command would look like:


### PR DESCRIPTION
* Fix some minor typos in the README's across all labs like the extra space in the pytest call: `pytest --capture=tee-sys --log-cli-level=INFO tests/test_MyAxiStreamModuleWrapper.py  | grep CUSTOM`
* Lab 03 instructions as written gave me an error regarding the AXI-Lite signals being defined twice:
```
ERROR    cocotb:simulator.py:305 /home/jpsmith/surf-tutorials/test/surf-tutorial/labs/03-AXI-Lite_crossbar/build/SRC_VHDL/work/MyAxiLiteCrossbar.vhd:59:11: identifier "axilclk" already used for a declaration
ERROR    cocotb:simulator.py:305 /home/jpsmith/surf-tutorials/test/surf-tutorial/labs/03-AXI-Lite_crossbar/build/SRC_VHDL/work/MyAxiLiteCrossbar.vhd:29:7: previous declaration: port "axilclk"
ERROR    cocotb:simulator.py:305 /home/jpsmith/surf-tutorials/test/surf-tutorial/labs/03-AXI-Lite_crossbar/build/SRC_VHDL/work/MyAxiLiteCrossbar.vhd:60:11: identifier "axilrst" already used for a declaration
ERROR    cocotb:simulator.py:305 /home/jpsmith/surf-tutorials/test/surf-tutorial/labs/03-AXI-Lite_crossbar/build/SRC_VHDL/work/MyAxiLiteCrossbar.vhd:30:7: previous declaration: port "axilrst"
ERROR    cocotb:simulator.py:305 /home/jpsmith/surf-tutorials/test/surf-tutorial/labs/03-AXI-Lite_crossbar/build/SRC_VHDL/work/MyAxiLiteCrossbar.vhd:62:11: identifier "axilreadmaster" already used for a declaration
ERROR    cocotb:simulator.py:305 /home/jpsmith/surf-tutorials/test/surf-tutorial/labs/03-AXI-Lite_crossbar/build/SRC_VHDL/work/MyAxiLiteCrossbar.vhd:31:7: previous declaration: port "axilreadmaster"
ERROR    cocotb:simulator.py:305 /home/jpsmith/surf-tutorials/test/surf-tutorial/labs/03-AXI-Lite_crossbar/build/SRC_VHDL/work/MyAxiLiteCrossbar.vhd:63:11: identifier "axilreadslave" already used for a declaration
ERROR    cocotb:simulator.py:305 /home/jpsmith/surf-tutorials/test/surf-tutorial/labs/03-AXI-Lite_crossbar/build/SRC_VHDL/work/MyAxiLiteCrossbar.vhd:32:7: previous declaration: port "axilreadslave"
ERROR    cocotb:simulator.py:305 /home/jpsmith/surf-tutorials/test/surf-tutorial/labs/03-AXI-Lite_crossbar/build/SRC_VHDL/work/MyAxiLiteCrossbar.vhd:64:11: identifier "axilwritemaster" already used for a declaration
ERROR    cocotb:simulator.py:305 /home/jpsmith/surf-tutorials/test/surf-tutorial/labs/03-AXI-Lite_crossbar/build/SRC_VHDL/work/MyAxiLiteCrossbar.vhd:33:7: previous declaration: port "axilwritemaster"
ERROR    cocotb:simulator.py:305 /home/jpsmith/surf-tutorials/test/surf-tutorial/labs/03-AXI-Lite_crossbar/build/SRC_VHDL/work/MyAxiLiteCrossbar.vhd:65:11: identifier "axilwriteslave" already used for a declaration
ERROR    cocotb:simulator.py:305 /home/jpsmith/surf-tutorials/test/surf-tutorial/labs/03-AXI-Lite_crossbar/build/SRC_VHDL/work/MyAxiLiteCrossbar.vhd:34:7: previous declaration: port "axilwriteslave"
```
Fixed by removing the duplicate AXI-Lite signal declarations in "-- Placeholder for signals" (removed associated documentation in README as well because it's duplicated from the MyAxiLiteCrossbar entity definition documentation).
* Fixed a typo in the Lab 3 entity definition code block `end MyAxiLiteCrossbarWrapper` --> `end MyAxiLiteCrossbar`
* Added missing code-paste directions in Lab 2 README for consistency.