### PR TITLE
replace metadata with side-channel data

### DIFF
--- a/labs/01-AXI-Lite_register_endpoint/README.md
+++ b/labs/01-AXI-Lite_register_endpoint/README.md
@@ -368,7 +368,7 @@ address `0x----_-004` is  detected, a read (or write) transaction on
 the `scratchPad` will occur.
 
 Note: The address is in units of bytes.  AXI-Lite is a 32-bit transaction with the
-`wstrb` metadata field to do byte level `write` transactions.  We recommend using 32-bit
+`wstrb` side-channel data field to do byte level `write` transactions.  We recommend using 32-bit
 word strides (4 bytes) for mapping the addresses because it is more human readable
 and helps with mapping the registers from firmware to software.
 

--- a/labs/02-AXI-stream_module/README.md
+++ b/labs/02-AXI-stream_module/README.md
@@ -64,10 +64,10 @@ Primary purpose is to help with visually looking at simulation waveforms.
 Generic that contain the AXI stream configurations
   - TSTRB_EN_C         : boolean; -- Configure if tStrb used or not
   - TDATA_BYTES_C      : natural range 1 to AXI_STREAM_MAX_TKEEP_WIDTH_C; -- tData width (in units of bytes)
-  - TDEST_BITS_C       : natural range 0 to 8; -- Number of tDest bits (optional metadata field)
-  - TID_BITS_C         : natural range 0 to 8; -- Number of tId bits (optional metadata field)
+  - TDEST_BITS_C       : natural range 0 to 8; -- Number of tDest bits (optional side-channel data field)
+  - TID_BITS_C         : natural range 0 to 8; -- Number of tId bits (optional side-channel data field)
   - TKEEP_MODE_C       : TkeepModeType; -- Method for tKeep implementation to improve logical resource utilization
-  - TUSER_BITS_C       : natural range 0 to 8; -- Number of tUser bits (optional metadata field)
+  - TUSER_BITS_C       : natural range 0 to 8; -- Number of tUser bits (optional side-channel data field)
   - TUSER_MODE_C       : TUserModeType; -- Method for tUser implementation to improve logical resource utilization
 * `axisClk`: AXI stream clock
 * `axisRst`: AXI stream reset (active HIGH)
@@ -176,7 +176,7 @@ Next, add the following code to the "Flow Control" section:
       -- Check if the outbound tReady was active
       if (mAxisSlave.tReady = '1') then
 
-         -- Reset the outbound metadata
+         -- Reset the outbound side-channel data
          v.mAxisMaster.tValid := '0';
 
       end if;

--- a/labs/02-AXI-stream_module/ref_files/MyAxiStreamModule_final.vhd
+++ b/labs/02-AXI-stream_module/ref_files/MyAxiStreamModule_final.vhd
@@ -72,7 +72,7 @@ begin
       -- Check if the outbound tReady was active
       if (mAxisSlave.tReady = '1') then
 
-         -- Reset the outbound metadata
+         -- Reset the outbound side-channel data
          v.mAxisMaster.tValid := '0';
 
       end if;


### PR DESCRIPTION
This is a pretty minor nit and might not make sense depending on the documentation in the rest of the repos but "AXI metadata" seems to be kind of a one-off term. For the sake of keeping tutorials consistent with AMD/Xilinx maintained documentation, I changed references to "AXI metadata" to "AXI side-channel data" to be consistent to how these signals are discussed in most official AMD/Xilinx documentation ([for example](https://docs.amd.com/r/en-US/ug1399-vitis-hls/AXI4-Stream-Interfaces-with-Side-Channels?tocId=LowLue8vkVbhMM3618_5HA)). 